### PR TITLE
Add absolute positioning to NavBar

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -51,7 +51,7 @@ const Navigation = () => {
       </div>
 
       <div
-        className={`fixed top-24 z-10 w-full flex-col items-center justify-evenly bg-csa-red-200 md:hidden ${
+        className={`absolute top-24 z-10 w-full flex-col items-center justify-evenly bg-csa-red-200 md:hidden ${
           mobileScreen ? "flex" : "hidden"
         }`}
       >


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2a83004c-fece-41cf-9a29-ba272983d4c6)
![image](https://github.com/user-attachments/assets/821fb62c-0758-45f4-8d46-3d465ce75cca)
Navbar stays at top now 