### PR TITLE
Remove flex and flex-col in BoardCard

### DIFF
--- a/src/components/board/BoardCard.tsx
+++ b/src/components/board/BoardCard.tsx
@@ -17,7 +17,7 @@ const BoardCard: React.FC<BoardCardProps> = ({ image, name, title, index }) => {
   const diamondColor =
     diamondImages[Math.floor(index / 3) % diamondImages.length];
   return (
-    <div className="flex flex-col text-center">
+    <div className="text-center">
       <div className="relative flex justify-center">
         <Image src={diamondColor} alt="redDiamond" className="w-auto" />
         <Image


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/b0be251d-7e2c-4558-976e-8582a4410351)


I kept the div tag but just removed the flex and flex-col.