### PR TITLE
Updating goat sizes on larger screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2970,6 +2970,7 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.5.2.tgz",
       "integrity": "sha512-Tmx+uY3MqseIGdwp0ScyUuxpBgx5jX1f7od4Cm5mDwg/dptEiTKf9xp6tw0lZN2VA9JbnVMl/aikmbc53c6QFA==",
+      "license": "MIT",
       "dependencies": {
         "embla-carousel": "8.5.2",
         "embla-carousel-reactive-utils": "8.5.2"

--- a/src/components/home/MemberExperiences.tsx
+++ b/src/components/home/MemberExperiences.tsx
@@ -25,9 +25,9 @@ const MemberExperiences = () => {
       <Image
         src={Ram}
         alt="Chinese Ram"
-        className="absolute left-[3vw] w-6/12 translate-y-[-12vh] md:w-4/12 md:translate-y-[-16vh] lg:translate-y-[-13vh]"
+        className="absolute left-[3vw] w-6/12 translate-y-[-12vh] md:w-4/12 md:translate-y-[-16vh] lg:w-1/4 lg:translate-y-[-10vh] xl:w-1/4 xl:translate-y-[-2vh] 2xl:translate-y-[-4vh]"
       />
-      <p className="flex justify-end pb-[4vh] pr-4 pt-[10vh] text-4xl font-semibold text-csa-red-100 md:pr-[15vw] md:text-6xl lg:py-[5vh] xl:py-[15vh]">
+      <p className="flex justify-end pb-[4vh] pr-4 pt-[10vh] text-4xl font-semibold text-csa-red-100 md:text-5xl xl:py-[15vh]">
         Member Experiences
       </p>
     </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4eb3a899-d093-4da9-8cdc-d06fc0ab4732)
Note: I changed the sizes for 2xl, xl, and lg screens, but I noticed on tablet that there was extra padding on the right due to the navbar button. Also had to add npm install embla-carousel-react cuz I was getting an error for a missing dependency. 